### PR TITLE
Add SR data source

### DIFF
--- a/website/docs/d/sr.md
+++ b/website/docs/d/sr.md
@@ -1,0 +1,19 @@
+---
+title: "xenserver_sr"
+---
+
+Provides information about the storage repositories (SRs) of a XenServer host.
+
+## Example Usage
+
+```hcl
+data "xenserver_sr" "local-storage" {
+  name_label = "Local storage"
+}
+
+resource "xenserver_vdi" "demo-vdi" {
+  sr_uuid = "${data.xenserver_sr.local-storage.id}"
+  name_label = "Demo"
+  size = 536870912000
+}
+```

--- a/xenserver/data_source_sr.go
+++ b/xenserver/data_source_sr.go
@@ -1,0 +1,52 @@
+package xenserver
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceXenServerSR() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceXenServerSRRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_label": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The human readable name of the storage repository",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func dataSourceXenServerSRRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Connection)
+
+	nameLabel, nameLabelOk := d.GetOk("name_label")
+
+	if !nameLabelOk {
+		return fmt.Errorf("name_label must be provided")
+	}
+
+	if srs, err := c.client.SR.GetByNameLabel(c.session, nameLabel.(string)); err == nil {
+		found := false
+		for _, sr := range srs {
+			record, err := c.client.SR.GetRecord(c.session, sr)
+			if err != nil {
+				break
+			}
+
+			d.SetId(record.UUID)
+
+			found = true
+			break
+		}
+
+		if !found {
+			return fmt.Errorf("Matching SR not found")
+		}
+	}
+
+	return nil
+}

--- a/xenserver/provider.go
+++ b/xenserver/provider.go
@@ -33,6 +33,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"xenserver_pifs": dataSourceXenServerPifs(),
+			"xenserver_sr": dataSourceXenServerSR(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
Allows a Terraform configuration to dynamically determine the SR UUID to
be used when creating new VDI resources. For example:

    data "xenserver_sr" "local-storage" {
      name_label = "Local storage"
    }

    resource "xenserver_vdi" "demo-vdi" {
      sr_uuid = "${data.xenserver_sr.local-storage.id}"
      name_label = "Demo"
      size = 536870912000
    }